### PR TITLE
Failing test for finding procs that include the / character

### DIFF
--- a/spec/proc/to_source_from_multi_blocks_w_specified_attached_to_and_single_match_spec.rb
+++ b/spec/proc/to_source_from_multi_blocks_w_specified_attached_to_and_single_match_spec.rb
@@ -8,6 +8,11 @@ describe 'Proc#to_source w specified {:attached_to => ...} & single match' do
     b1 = lambda {|a| @x1+1 }; b2 = watever { @x1+2 }; b3 = lambda { @x1+3 }
     b2.should.be having_source('proc { @x1+2 }', options)
   end
+  
+  should 'handle no nesting on same line with the / character' do
+    b1 = lambda {|a| @x1+1 }; b2 = watever { @x1/2 }; b3 = lambda { @x1+3 }
+    b2.should.be having_source('proc { @x1/2 }', options)
+  end
 
   should 'handle single level nesting on same line' do
     b1 = lambda {|a| @x2+1 }; b2 = watever { lambda { @x2+2 } }


### PR DESCRIPTION
hi!

Here's a strange error that affects our code.

Best,
Seamus

PS. Thanks for :attached_to, it solves the problems I had when I couldn't use ParseTree any more!
