### PR TITLE
fix "already initialized constant X" from ruby_parser

### DIFF
--- a/lib/sourcify.rb
+++ b/lib/sourcify.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
-require 'ruby2ruby'
-require 'sexp_processor'
 require 'ruby_parser'
+require 'sexp_processor'
+require 'ruby2ruby'
 require 'file/tail'
 
 begin


### PR DESCRIPTION
`cat t.rb`:

``` ruby
require 'sourcify'
```

emits:

```
/Users/jmettraux/.rvm/gems/ruby-1.9.3-p194/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:10: warning: already initialized constant ENC_NONE
/Users/jmettraux/.rvm/gems/ruby-1.9.3-p194/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:11: warning: already initialized constant ENC_EUC
/Users/jmettraux/.rvm/gems/ruby-1.9.3-p194/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:12: warning: already initialized constant ENC_SJIS
/Users/jmettraux/.rvm/gems/ruby-1.9.3-p194/gems/ruby_parser-2.3.1/lib/ruby_parser_extras.rb:13: warning: already initialized constant ENC_UTF8
```

This patch silences that (by requiring ruby_parser first).

Many thanks for sourcify!

John
