### PR TITLE
added IRB multi support

### DIFF
--- a/lib/sourcify/common/parser/source_code.rb
+++ b/lib/sourcify/common/parser/source_code.rb
@@ -9,7 +9,7 @@ module Sourcify
 
         def to_s
           case file
-          when /\(irb\)/ then from_irb_to_s
+          when /\(irb\)/, /\(irb\#\d+\)/ then from_irb_to_s
           when /\(pry\)/ then from_pry_to_s
           else from_file_to_s
           end


### PR DESCRIPTION
Not sure how you want to go about the regex here so I added it as an OR in the case statement.

Reason for PR: You can have a multi context IRB session, and the 'file' name of that session isn't '(irb)' like a normal session, but it is '(irb#1)' or what ever the session number is. The additional #\d+ in the regex should now pick this up.

Reproduce

``` ruby
require 'irb'
IRB.setup nil
IRB.conf[:MAIN_CONTEXT] = IRB::Irb.new.context
require 'irb/ext/multi-irb'
IRB.irb nil, self
```

This IRB feature was found here http://stackoverflow.com/questions/4189818/how-to-run-irb-start-in-context-of-current-class/4987732#4987732
