### PR TITLE
Support UnboundMethod objects.

### DIFF
--- a/lib/sourcify/method.rb
+++ b/lib/sourcify/method.rb
@@ -132,3 +132,7 @@ end
 Method.class_eval do
   include Sourcify::Method
 end
+
+UnboundMethod.class_eval do
+  include Sourcify::Method
+end


### PR DESCRIPTION
This code snippet does not work right now:

``` ruby
class X
    def bar
        1 + 2
    end
end

X.instance_method(:bar).to_source
```
